### PR TITLE
Fix date issues with the description updater

### DIFF
--- a/backend/sheets/sheets.py
+++ b/backend/sheets/sheets.py
@@ -45,11 +45,11 @@ class Sheets(commands.Cog):
                 backend.config.inktober_submit_channel
             )
             topics = []
-            if (now_day - 1) in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
+            if (now_day - 1) in backend.day_themes.day_themes.keys() and (now_date - datetime.timedelta(-1)).month == self.ink_month:
                 topics.append(f"{now_day - 1}: {backend.day_themes.day_themes[now_day - 1]}")
             if now_day in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
                 topics.append(f"{now_day}: {backend.day_themes.day_themes[now_day]}")
-            if (now_day + 1) in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
+            if (now_day + 1) in backend.day_themes.day_themes.keys() and (now_date - datetime.timedelta(1)).month == self.ink_month:
                 topics.append(f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}")
 
             topic_str = f"Currently accepting - " + topics.join(", ") if topics else "No longer accepting any days"

--- a/backend/sheets/sheets.py
+++ b/backend/sheets/sheets.py
@@ -43,12 +43,18 @@ class Sheets(commands.Cog):
             channel: discord.TextChannel = self.bot.get_channel(
                 backend.config.inktober_submit_channel
             )
+            topics = []
+            if (now_day - 1) in backend.day_themes.day_themes.keys():
+                topics.append(f"{now_day - 1}: {backend.day_themes.day_themes[now_day - 1]}")
+            if now_day in backend.day_themes.day_themes.keys():
+                topics.append(f"{now_day}: {backend.day_themes.day_themes[now_day]}")
+            if (now_day + 1) in backend.day_themes.day_themes.keys():
+                topics.append(f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}")
+
+            topic_str = f"Currently accepting: " + topics.join(", ") if topics else "No longer accepting any days"
             await channel.edit(
                 reason="Time passed",
-                topic=f"Currently accepting "
-                f"{now_day - 1}: {backend.day_themes.day_themes[now_day - 1]},"
-                f"{now_day}: {backend.day_themes.day_themes[now_day]},"
-                f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}",
+                topic=topic_str
             )
             self.current_day = now_day
 

--- a/backend/sheets/sheets.py
+++ b/backend/sheets/sheets.py
@@ -52,7 +52,7 @@ class Sheets(commands.Cog):
             if (now_day + 1) in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
                 topics.append(f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}")
 
-            topic_str = f"Currently accepting: " + topics.join(", ") if topics else "No longer accepting any days"
+            topic_str = f"Currently accepting - " + topics.join(", ") if topics else "No longer accepting any days"
             await channel.edit(
                 reason="Time passed",
                 topic=topic_str

--- a/backend/sheets/sheets.py
+++ b/backend/sheets/sheets.py
@@ -35,7 +35,7 @@ class Sheets(commands.Cog):
     async def channel_description(self):
         now_date = datetime.datetime.now(tz=datetime.timezone.utc)
         now_day = int(now_date.strftime("%d"))
-        tomorrow_date, until_tomorrow = await get_tomorrow_day()
+        tomorrow_date, until_tomorrow = await self.get_tomorrow_day()
         if now_day == self.current_day:
             # Annoying solution to fill the feature gap of scheduled tasks not being implemented yet in d.py
             await asyncio.sleep(until_tomorrow)
@@ -52,7 +52,7 @@ class Sheets(commands.Cog):
             if (now_day + 1) in backend.day_themes.day_themes.keys() and (now_date - datetime.timedelta(1)).month == self.ink_month:
                 topics.append(f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}")
 
-            topic_str = f"Currently accepting - " + topics.join(", ") if topics else "No longer accepting any days"
+            topic_str = f"Currently accepting - " + ", ".join(topics) if topics else "No longer accepting any days"
             await channel.edit(
                 reason="Time passed",
                 topic=topic_str
@@ -60,7 +60,7 @@ class Sheets(commands.Cog):
             self.current_day = now_day
 
 
-    async def get_tomorrow_day():
+    async def get_tomorrow_day(self):
         tomorrow = datetime.datetime.utcnow() + datetime.timedelta(1)
         min_time = datetime.datetime.combine(tomorrow, datetime.time())
         now = datetime.datetime.utcnow()

--- a/backend/sheets/sheets.py
+++ b/backend/sheets/sheets.py
@@ -24,6 +24,7 @@ class Sheets(commands.Cog):
     def __init__(self, bot):
         self.bot: Client = bot
         self.current_day = None
+        self.ink_month = 10 # October
         self.channel_description.start()
 
     def cog_unload(self):
@@ -44,11 +45,11 @@ class Sheets(commands.Cog):
                 backend.config.inktober_submit_channel
             )
             topics = []
-            if (now_day - 1) in backend.day_themes.day_themes.keys():
+            if (now_day - 1) in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
                 topics.append(f"{now_day - 1}: {backend.day_themes.day_themes[now_day - 1]}")
-            if now_day in backend.day_themes.day_themes.keys():
+            if now_day in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
                 topics.append(f"{now_day}: {backend.day_themes.day_themes[now_day]}")
-            if (now_day + 1) in backend.day_themes.day_themes.keys():
+            if (now_day + 1) in backend.day_themes.day_themes.keys() and now_date.month == self.ink_month:
                 topics.append(f"{now_day + 1}: {backend.day_themes.day_themes[now_day + 1]}")
 
             topic_str = f"Currently accepting: " + topics.join(", ") if topics else "No longer accepting any days"


### PR DESCRIPTION
## This PR accomplishes two things:
#### Makes the topic change much more precise after the next day begins in UTC
* Sets an internal state of the tracked day, and if that does not match the current day then updates the channel topic with the new ink subjects
* [Hacky] If the date tracked and current date match on the loop, it will wait until the new day and immediately update the channel topic after

#### Fixes any potential KeyError at certain dates or posting old topics
* If a date is not present in the day_themes, don't include it
* If the day would be in a month other than what is set in `ink_month`, don't that topic
* If the event has no more topics, say so instead of doing nothing